### PR TITLE
Update devcontainer settings

### DIFF
--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -12,6 +12,6 @@ echo Install .NET dev certs
 dotnet dev-certs https --trust
 
 echo Install uv for Python
-curl -LsSf https://astral.sh/uv/install.sh | sh
+sudo curl -LsSf https://astral.sh/uv/install.sh | sh
 
 echo Done!


### PR DESCRIPTION
This PR is:

- To install `uv` by default while initiating the devcontainer.
