### PR TITLE
Add API endpoint to retrieve users who liked a post and update docume…

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.32/17d46b3e205515e1e8efd3ee4d57ce8018914163/lombok-1.18.32.jar" />
+        </processorPath>
+        <module name="socialapp.main" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/github-copilot-vibe-coding-workshop.iml
+++ b/.idea/github-copilot-vibe-coding-workshop.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/complete/java/socialapp" />
+        <option name="gradleJvm" value="21" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/complete/java/socialapp" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/github-copilot-vibe-coding-workshop.iml" filepath="$PROJECT_DIR$/.idea/github-copilot-vibe-coding-workshop.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/complete/java/README.md
+++ b/complete/java/README.md
@@ -171,6 +171,14 @@ Open your browser and navigate to:
 
 - `POST /api/posts/{postId}/like` - Like a post
 - `DELETE /api/posts/{postId}/like` - Unlike a post
+- `GET /api/posts/{postId}/likes/users` - Get all usernames who liked a post
+
+#### Example: Get users who liked a post
+
+```bash
+curl http://localhost:8080/api/posts/1/likes/users
+# Response: ["alice", "bob", "charlie"]
+```
 
 ### Spring Boot Actuator
 

--- a/complete/java/socialapp/src/main/java/com/contoso/socialapp/controller/LikeController.java
+++ b/complete/java/socialapp/src/main/java/com/contoso/socialapp/controller/LikeController.java
@@ -68,4 +68,21 @@ public class LikeController {
             throw new RuntimeException("INTERNAL_SERVER_ERROR: " + e.getMessage());
         }
     }
+
+    @GetMapping("/users")
+    @Operation(summary = "Get users who liked a post", description = "Retrieve a list of usernames who have liked the specified post.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved list of users who liked the post"),
+        @ApiResponse(responseCode = "404", description = "Post not found"),
+        @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public ResponseEntity<java.util.List<String>> getUsersWhoLikedPost(@PathVariable String postId) {
+        try {
+            java.util.List<String> users = likeService.getUsernamesByPostId(postId);
+            return ResponseEntity.ok(users);
+        } catch (Exception e) {
+            log.error("Error fetching users who liked post ID: " + postId, e);
+            throw new RuntimeException("INTERNAL_SERVER_ERROR: " + e.getMessage());
+        }
+    }
 }

--- a/complete/java/socialapp/src/main/java/com/contoso/socialapp/repository/LikeRepository.java
+++ b/complete/java/socialapp/src/main/java/com/contoso/socialapp/repository/LikeRepository.java
@@ -17,4 +17,7 @@ public interface LikeRepository extends JpaRepository<Like, LikeId> {
     
     @Query("DELETE FROM Like l WHERE l.post.id = :postId AND l.username = :username")
     void deleteByPostIdAndUsername(@Param("postId") String postId, @Param("username") String username);
+
+    @Query("SELECT l.username FROM Like l WHERE l.post.id = :postId")
+    java.util.List<String> findUsernamesByPostId(@Param("postId") String postId);
 }

--- a/complete/java/socialapp/src/main/java/com/contoso/socialapp/service/LikeService.java
+++ b/complete/java/socialapp/src/main/java/com/contoso/socialapp/service/LikeService.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -66,6 +67,11 @@ public class LikeService {
         return false;
     }
     
+    public List<String> getUsernamesByPostId(String postId) {
+        log.info("Fetching usernames who liked post ID: {}", postId);
+        return likeRepository.findUsernamesByPostId(postId);
+    }
+
     private LikeResponse convertToResponse(Like like) {
         return new LikeResponse(
                 like.getPostId(),

--- a/complete/javascript/src/api/apiService.js
+++ b/complete/javascript/src/api/apiService.js
@@ -26,6 +26,9 @@ export const postApi = {
   // 포스트 좋아요 취소 (DELETE)
   unlikePost: (postId) =>
     apiClient.delete(`/posts/${postId}/likes`),
+
+  // Lấy danh sách username đã like một post
+  getPostLikesUsers: (postId) => apiClient.get(`/posts/${postId}/likes/users`),
 };
 
 export const commentApi = {

--- a/complete/javascript/src/pages/PostDetailPage.jsx
+++ b/complete/javascript/src/pages/PostDetailPage.jsx
@@ -49,6 +49,7 @@ const PostDetailPage = () => {
   const [error, setError] = useState("");
   const [isLiked, setIsLiked] = useState(false);
   const [likesCount, setLikesCount] = useState(0);
+  const [likesUsers, setLikesUsers] = useState([]);
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -83,6 +84,16 @@ const PostDetailPage = () => {
     }
   }, [postId]);
 
+  // Fetch users who liked this post
+  const fetchLikesUsers = useCallback(async () => {
+    try {
+      const response = await postApi.getPostLikesUsers(postId);
+      setLikesUsers(response.data);
+    } catch (error) {
+      setLikesUsers([]);
+    }
+  }, [postId]);
+
   useEffect(() => {
     fetchPostDetail();
   }, [fetchPostDetail]);
@@ -92,6 +103,10 @@ const PostDetailPage = () => {
       fetchComments();
     }
   }, [fetchComments, postId]);
+
+  useEffect(() => {
+    fetchLikesUsers();
+  }, [fetchLikesUsers]);
 
   const handleLikeToggle = async () => {
     if (!user) return;
@@ -105,6 +120,8 @@ const PostDetailPage = () => {
         setLikesCount(response.data.likesCount);
         setIsLiked(true);
       }
+      // Refetch likes users after like/unlike
+      fetchLikesUsers();
     } catch (error) {
       console.error("Error toggling like:", error);
     }
@@ -286,6 +303,9 @@ const PostDetailPage = () => {
               <HeartIcon filled={isLiked} />
               {likesCount > 0 && <span className="text-xs">{likesCount}</span>}
             </button>
+            {likesUsers.length > 0 && (
+              <span className="text-xs text-gray-500">Liked by: {likesUsers.join(", ")}</span>
+            )}
             <span className="text-sm text-gray-600">
               Comments {post.commentsCount}
             </span>

--- a/complete/javascript/vite.config.js
+++ b/complete/javascript/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
     open: true,
     proxy: {
       '/api': {
-        target: 'http://0.0.0.0:8000',
+        target: 'http://0.0.0.0:8080',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add API and UI feature to display the list of users who liked a post. This allows users to see who has liked a specific post, improving transparency and engagement.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
# Start backend (Java Spring Boot)
cd complete/java/socialapp
./gradlew bootRun

# Start frontend (React)
cd ../../javascript
yarn install
yarn dev

# Open http://localhost:3000, go to a post detail page, and check the list of users who liked the post under the like button.
```

## What to Check
Verify that the following are valid
* The list of users who liked a post is displayed under the like button on the post detail page.
* The list updates immediately after liking or unliking a post.
* No errors appear in the browser console or backend logs.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
* The new API endpoint is: `GET /api/posts/{postId}/likes/users` (Java backend)
* The React UI calls this endpoint and renders the usernames under the like button.
* This feature is fully documented in the backend Swagger UI.
